### PR TITLE
Make updateCreds only overwrite relevant keys, and not the whole INI section.

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -63,15 +63,23 @@ function updateCreds(key, profile, force){
         awsCreds    = propIni.decode({ file: credFile  }),
         section     = profile || 'default';
 
-    if(_.has(awsCreds.sections, section) && !force){
-        utils.errorAndExit('\nThe ' + section + ' profile already exists in AWS credentials. Please pass -f to force overwrite.');
+    if(_.has(awsCreds.sections, section)){
+        if (force){
+            // overwrite only the relevant keys and leave the rest of the section untouched
+            propIni.addData(key.accessKey, section, "aws_access_key_id" );
+            propIni.addData(key.secretKey, section, "aws_secret_access_key");
+            propIni.addData(key.sessionToken, section, "aws_session_token");
+        } else {
+            utils.errorAndExit('\nThe ' + section + ' profile already exists in AWS credentials. Please pass -f to force overwrite.');
+        }
+    } else {
+        // add brand new section
+        propIni.addData({
+            aws_access_key_id: key.accessKey,
+            aws_secret_access_key: key.secretKey,
+            aws_session_token: key.sessionToken
+        }, section);
     }
-
-    propIni.addData({
-        aws_access_key_id: key.accessKey,
-        aws_secret_access_key: key.secretKey,
-        aws_session_token: key.sessionToken
-    }, section);
 
     propIni.encode({ file: credFile  });
 


### PR DESCRIPTION
This allows the profile in the ~/.aws/credentials file to retain other keys, such as region, if the credentials-related keys are updated.