### PR TITLE
2.7.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ docker run -it -v ~:/root coxauto/alks-cli
 
 `alks developer accounts` - Show all available ALKS accounts (both Standard and IAM)
 
+Optional arguments:
+
+* `-e` Output as environment variables for creating account shortcuts
+
+
 ## Sessions
 
 ### `sessions open`

--- a/bin/alks-developer-accounts
+++ b/bin/alks-developer-accounts
@@ -41,11 +41,11 @@ function getUniqueAccountName(accountName){
     return test;
 }
 
-function accountExport(account, suffix){
+function accountExport(account){
     var match;
     while(match = accountRegex.exec(account)){
         if(match && account.indexOf('ALKS_') === -1){ // ignore legacy accounts
-            var accountName = getUniqueAccountName(match[6].toLowerCase() + '_' + match[4].toLowerCase() + suffix);
+            var accountName = getUniqueAccountName([ match[6].toLowerCase(), match[4].toLowerCase() ].join('_'));
             accounts.push(accountName)
             console.log('export ' + accountName + '="' + account + '"')
         }
@@ -83,7 +83,7 @@ function(err, developer, password, alksAccounts, alksIamAccounts){
         var data = val.split(alks.getAccountSelectorDelimiter());
 
         if(doExport){
-            accountExport(data[0], '')
+            accountExport(data[0])
         }
         else{
             table.push(data.concat('Standard'));
@@ -94,7 +94,7 @@ function(err, developer, password, alksAccounts, alksIamAccounts){
         var data = val.split(alks.getAccountSelectorDelimiter());
 
         if(doExport){
-            accountExport(data[0], '');
+            accountExport(data[0]);
         }
         else{
             table.push(data.concat('IAM'));

--- a/bin/alks-developer-accounts
+++ b/bin/alks-developer-accounts
@@ -17,6 +17,7 @@ program
     .version(config.version)
     .description('shows current developer configuration')
     .option('-v, --verbose', 'be verbose')
+    .option('-e, --export', 'export accounts to environment variables')
     .parse(process.argv);
 
 var table = new Table({
@@ -24,7 +25,32 @@ var table = new Table({
     colWidths: [50, 50, 25]
 });
 
-var logger = 'dev-accounts';
+var logger       = 'dev-accounts',
+    doExport     = program['export'],
+    accountRegex = utils.getAccountRegex(),
+    accounts     = [];
+
+function getUniqueAccountName(accountName){
+    var i = 1,
+        test = accountName;
+
+    while(_.contains(accounts, test)){
+        test = accountName + i++;
+    }
+
+    return test;
+}
+
+function accountExport(account, suffix){
+    var match;
+    while(match = accountRegex.exec(account)){
+        if(match && account.indexOf('ALKS_') === -1){ // ignore legacy accounts
+            var accountName = getUniqueAccountName(match[6].toLowerCase() + '_' + match[4].toLowerCase() + suffix);
+            accounts.push(accountName)
+            console.log('export ' + accountName + '="' + account + '"')
+        }
+    }
+}
 
 async.waterfall([
     // get developer
@@ -52,16 +78,33 @@ async.waterfall([
     }
 ],
 function(err, developer, password, alksAccounts, alksIamAccounts){
+
     _.each(alksAccounts, function(val, key){
-        table.push(val.split(alks.getAccountSelectorDelimiter()).concat('Standard'));
+        var data = val.split(alks.getAccountSelectorDelimiter());
+
+        if(doExport){
+            accountExport(data[0], '')
+        }
+        else{
+            table.push(data.concat('Standard'));
+        }
     });
 
     _.each(alksIamAccounts, function(val, key){
-        table.push(val.split(alks.getAccountSelectorDelimiter()).concat('IAM'));
+        var data = val.split(alks.getAccountSelectorDelimiter());
+
+        if(doExport){
+            accountExport(data[0], '');
+        }
+        else{
+            table.push(data.concat('IAM'));
+        }
     });
 
-    console.error(clc.white.underline.bold('\nAvailable Accounts'));
-    console.error(clc.white(table.toString()));
+    if(!doExport){
+        console.error(clc.white.underline.bold('\nAvailable Accounts'));
+        console.error(clc.white(table.toString()));
+    }
 
     utils.log(program, logger, 'checking for update');
     utils.checkForUpdate();

--- a/bin/alks-iam-createrole
+++ b/bin/alks-iam-createrole
@@ -43,6 +43,11 @@ if(_.isEmpty(roleType)){
     utils.errorAndExit('The role type is required');
 }
 
+if(_.isUndefined(alksRole)){
+    utils.log(program, logger, 'trying to extract role from account');
+    alksRole = utils.tryToExtractRole(alksAccount);
+}
+
 Iam.getIAMKey(program, logger, alksAccount, alksRole, function(err, key, developer, password){
     if(err){
         return utils.errorAndExit(err);

--- a/bin/alks-sessions-console
+++ b/bin/alks-sessions-console
@@ -35,6 +35,11 @@ var alksAccount       = program.account,
     output            = program.output,
     logger            = 'sessions-console';
 
+if(_.isUndefined(alksRole)){
+    utils.log(program, logger, 'trying to extract role from account');
+    alksRole = utils.tryToExtractRole(alksAccount);
+}
+
 var execute = function(){
     if(_.isUndefined(program.iam)){
         Sessions.getSessionKey(program, logger, alksAccount, alksRole, false, forceNewSession, onComplete);

--- a/bin/alks-sessions-open
+++ b/bin/alks-sessions-open
@@ -40,7 +40,6 @@ var alksAccount       = program.account,
 if(_.isUndefined(alksRole)){
     utils.log(program, logger, 'trying to extract role from account');
     alksRole = utils.tryToExtractRole(alksAccount);
-    console.log(alksRole)
 }
 
 var execute = function(){

--- a/bin/alks-sessions-open
+++ b/bin/alks-sessions-open
@@ -37,6 +37,12 @@ var alksAccount       = program.account,
     output            = program.output,
     logger            = 'sessions-open';
 
+if(_.isUndefined(alksRole)){
+    utils.log(program, logger, 'trying to extract role from account');
+    alksRole = utils.tryToExtractRole(alksAccount);
+    console.log(alksRole)
+}
+
 var execute = function(){
     if(_.isUndefined(program.iam)){
         Sessions.getSessionKey(program, logger, alksAccount, alksRole, false, forceNewSession, onComplete);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,12 @@
-Release Notes: 2017-03-21
-============================
+★ Release Notes: 2017-03-23 ★
+≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
+- Export account shortcuts: eval $(alks developer accounts -e)
+- After exporting you can make simpler calls: alks sessions open -a "$awsacsnp"
+- Role is now inferred from account for security v2 accounts, so -r is optional
 - Fix for issue running configure with only IAM accounts
-- Fix for list sessions reporting no active sessions
+- Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 
-☁☁☁  Happy Clouding! ☁☁☁
+☁☁☁☁☁☁  Happy Clouding! ☁☁☁☁☁☁

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,8 @@ var _        = require('underscore'),
 
 var exports = module.exports = {};
 
-var programCacher = null;
+var programCacher = null,
+    accountRegex  = /([0-9]*)(\/)(ALKS)([a-zA-Z]*)([- ]*)([a-zA-Z0-9_-]*)/g;
 
 throbber = throbber(function(str){
   process.stdout.write(str);
@@ -189,5 +190,20 @@ var getOwnerRWOnlyPermission = exports.getOwnerRWOnlyPermission = function(){
 };
 
 exports.getBadAccountMessage = function(){
-    return 'Unable to generate session, please validate your account and role.\nYour account should look like "123456789/ALKS_PowerUser - awsfoonp" and your role should look like "IAM-FOO-PowerUserAccess".\nBe sure to wrap them in quotes.';
+    return 'Unable to generate session, please validate your account and role.\nYour account should look like "123456789/ALKSPowerUser - awsfoonp" and your role should look like "PowerUser".\nBe sure to wrap them in quotes.';
 };
+
+exports.getAccountRegex = function(){
+    return accountRegex;
+}
+
+exports.tryToExtractRole = function(account){
+    var match;
+    while(match = accountRegex.exec(account)){
+        if(match && account.indexOf('ALKS_') === -1){ // ignore legacy accounts
+            return match[4]
+        }
+    }
+
+    return null;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "alks",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "dependencies": {
     "alks-node": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alks",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "CLI for working with ALKS",
   "main": "bin/alks",
   "scripts": {


### PR DESCRIPTION
- Export account shortcuts: `eval $(alks developer accounts -e)`
- After exporting you can make simpler calls: `alks sessions open -a "$awsacsnp"`
- Role is now inferred from account for security v2 accounts, so `-r` is optional
