### PR TITLE
Pass windows platform to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ If you would rather run the ALKS CLI as a Docker container, simply run the follo
 docker run -it -v ~:/root coxauto/alks-cli
 ```
 
+If you are on a windows host and need SET instead of export then add a PLATFORM env:
+
+```
+docker run -it -e PLATFORM=windows -v %cd%:/root coxauto/alks-cli sessions open -a %AWS_ACCT% -r %AWS_ROLE% -o env 
+```
+
 # Commands
 
 ## Developer

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -it -v ~:/root coxauto/alks-cli
 If you are on a windows host and need SET instead of export then add a PLATFORM env:
 
 ```
-docker run -it -e PLATFORM=windows -v %cd%:/root coxauto/alks-cli sessions open -a %AWS_ACCT% -r %AWS_ROLE% -o env 
+docker run -it -e PLATFORM=windows -v %USERPROFILE%:/root coxauto/alks-cli sessions open -a %AWS_ACCT% -r %AWS_ROLE% -o env 
 ```
 
 # Commands

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,8 @@ exports.getDBFile = function(){
 };
 
 exports.isWindows = function(){
-    return /^win/.test(process.platform);
+    var platform = (process.env.PLATFORM) ? process.env.PLATFORM : process.platform;
+    return /^win/.test(platform);
 };
 
 exports.isOSX = function(){

--- a/test/alks.js
+++ b/test/alks.js
@@ -8,4 +8,41 @@ describe('alks-cli', function(){
     it('should write some tests', function(done){
         done();
     });
+
+    describe('utils', function() {
+        var utils = require('../lib/utils.js');
+
+        // isWindows test added to verify that sniffing process.env.PLATFORM
+        // doesn't break anything -- james.lance
+        describe('isWindows', function() {
+            var plat = process.platform;
+            // Basic sanity check here
+            it('isWindows is boolean', function() {
+                assert.isBoolean(utils.isWindows(), 'isWindows returns a Bool');
+            });
+
+            // This test is a bit quirky, but will change depending on what
+            // platform you are testing on
+            if (/^win/.test(plat)) {
+                it('native platform is Windows', function() {
+                    assert.equal(utils.isWindows(), true, 'isWindows detects the correct OS');
+                });
+            } else {
+                it('native platform is not Windows', function() {
+                    assert.equal(utils.isWindows(), false, 'isWindows detects the correct OS');
+                });
+            }
+
+            // Now test the environment variable override
+            it('setting env.platform=linux returns false', function() {
+                process.env['PLATFORM']='linux';
+                assert.isFalse(utils.isWindows(), 'not windows');
+            })
+
+            it('setting env.platform=windows returns true', function() {
+                process.env['PLATFORM']='windows';
+                assert.isTrue(utils.isWindows(), 'is windows');
+            })
+        });
+    });
 });


### PR DESCRIPTION
We ran into an issue where using alks under docker on windows was returning bash export statements.  By allowing isWindows to sniff an environment we can get SET statements instead.

We may need to loop back later for powershell options, but we don't need it at the moment.