### PR TITLE
Environment overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The ALKS CLI requires some basic environment information to get started. Simply 
 * Save Network Password: Whether or not to save your network password, we suggest saving your password for ease of use
 * Default Account/Role: Select the default ALKS account/role to use
 
-Alternately, some commands will work without configuration if the `ALKS_SERVER` and `ALKS_USERID` environment variables are set.
+Some commands will also work without configuration if the `ALKS_SERVER` and `ALKS_USERID` environment variables are set.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The ALKS CLI requires some basic environment information to get started. Simply 
 * Save Network Password: Whether or not to save your network password, we suggest saving your password for ease of use
 * Default Account/Role: Select the default ALKS account/role to use
 
+Alternately, some commands will work without configuration if the `ALKS_SERVER` and `ALKS_USERID` environment variables are set.
+
 ## Running
 
 After installing the ALKS CLI it will be available on your path. Simply run the following to see a list of supported commands:

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -235,6 +235,12 @@ exports.getDeveloper = function(callback){
               lastAcctUsed: data ? data.lastAcctUsed : null,
               outputFormat: data ? data.outputFormat : null
         };
+        if (process.env.ALKS_SERVER) {
+            resp.server = process.env.ALKS_SERVER
+        }
+        if (process.env.ALKS_USERID) {
+            resp.userid = process.env.ALKS_USERID
+        }
         callback(null, resp);
     });
 };

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -30,7 +30,7 @@ function encrypt(text, key){
     if(_.isEmpty(text)) text = '';
 
     var iv     = crypto.randomBytes(IV_LEN),
-        cipher = crypto.createCipheriv(ALGORITHM, new Buffer(getSizedEncryptionKey(key)), iv),
+        cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(getSizedEncryptionKey(key)), iv),
         encd   = cipher.update(text);
 
     encd = Buffer.concat([encd, cipher.final()]);
@@ -42,9 +42,9 @@ function decrypt(text, key){
     if(_.isEmpty(text)) return '';
 
     var parts    = text.split(PART_CHAR),
-        iv       = new Buffer(parts.shift(), ENCODING),
-        encd     = new Buffer(parts.join(PART_CHAR), ENCODING),
-        decipher = crypto.createDecipheriv(ALGORITHM, new Buffer(getSizedEncryptionKey(key)), iv),
+        iv       = Buffer.from(parts.shift(), ENCODING),
+        encd     = Buffer.from(parts.join(PART_CHAR), ENCODING),
+        decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(getSizedEncryptionKey(key)), iv),
         decrypt  = decipher.update(encd);
 
     decrypt = Buffer.concat([decrypt, decipher.final()]);


### PR DESCRIPTION
Allow server and userid to be set in the environment, so a user can retrieve a set of STS credentials without running `alks developer configure` interactively.