### PR TITLE
Fix for alks sessions list issue

### DIFF
--- a/bin/alks-sessions-list
+++ b/bin/alks-sessions-list
@@ -26,7 +26,12 @@ var logger = 'sessions-list';
 async.waterfall([
     // check to be sure were configured
     function(callback){
+        utils.log(program, logger, 'ensuring configured');
         Developer.ensureConfigured(callback);
+    },
+    function(callback){
+        utils.log(program, logger, 'removing expired keys');
+        keys.removeExpiredKeys(callback)
     },
     // get the password
     function(callback){

--- a/lib/iam.js
+++ b/lib/iam.js
@@ -47,6 +47,7 @@ exports.getIAMKey = function(program, logger, alksAccount, alksRole, forceNewSes
         // now retrieve existing keys
         function(developer, password, alksAccount, alksRole, callback){
             utils.log(program, logger, 'getting existing keys');
+            // TODO: This might rely on expired key pruning in keys.getKeys()
             keys.getKeys(password, true, function(err, keys){
                 utils.log(program, logger, 'got existing keys');
                 callback(err, developer, password, alksAccount, alksRole, keys);

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -137,15 +137,20 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
     });
 };
 
-exports.getKeys = function(password, isIAM, callback){
-    getKeysCollection(function(err, keys){
-        var now = new Date().getTime();
+exports.removeExpiredKeys = function(callback){
+    var now = new Date().getTime();
 
-        // first delete any expired keys
+    getKeysCollection(function(err, keys) {
         keys.removeWhere({ expires : { '$lte': now } });
         db.save();
+    });
+    callback(null);  // for chaining
+}
 
-        // now get valid keys, decrypt their values and return
+exports.getKeys = function(password, isIAM, callback){
+    getKeysCollection(function(err, keys){
+
+        // get valid keys, decrypt their values and return
         var data = keys
                     .chain()
                     .find({ isIAM : { '$eq': isIAM } })
@@ -164,7 +169,7 @@ exports.getKeys = function(password, isIAM, callback){
                 keydata.isIAM        = isIAM;
                 dataOut.push(keydata);
             } catch(e){
-                // console.warn('Error decrypting session data.', e.message);
+                console.warn('Error decrypting session data.', e.message);
             }
         });
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -53,6 +53,7 @@ exports.getSessionKey = function(program, logger, alksAccount, alksRole, iamOnly
         // now retrieve existing keys
         function(developer, password, alksAccount, alksRole, callback){
             utils.log(program, logger, 'getting existing keys');
+            // TODO: This may rely on expired key pruning in keys.getKeys()
             keys.getKeys(password, false, function(err, keys){
                 callback(null, developer, password, alksAccount, alksRole, keys);
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alks",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "CLI for working with ALKS",
   "main": "bin/alks",
   "scripts": {


### PR DESCRIPTION
This branch fixes an issue with alks sessions list.  Calling `alks sessions list` twice causes the non-IAM keys to initially be properly listed, then improperly encrypted when being written back out to the DB.  This is because the second call to `getKeys` called the `removeExpiredKeys` functionality.

I refactored the removeExpiredKeys into its own function earlier in the callback chain. 