### PR TITLE
escape hyperlink for ALKS server prompt input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The ALKS CLI requires some basic environment information to get started. Simply 
 
     alks developer configure
 
-* ALKS Server: The full URL to your ALKS server (ex: https://alks.company.com/rest)
+* ALKS Server: The full URL to your ALKS server (ex: `https://alks.company.com/rest`)
 * Network Username: Your network username
 * Network Password: Your network password (needed for loading list of accounts/roles)
 * Save Network Password: Whether or not to save your network password, we suggest saving your password for ease of use


### PR DESCRIPTION
`https://` portion of the url value was hidden, which is needed for the prompt input. Backtick clears up that `https://` is needed.