### PR TITLE
add -u option to alks session console to just get url

### DIFF
--- a/bin/alks-sessions-console
+++ b/bin/alks-sessions-console
@@ -18,6 +18,7 @@ var outputValues = utils.getOutputValues();
 program
     .version(config.version)
     .description('open an AWS console in your browser')
+    .option('-u, --url', 'just print the url')
     .option('-o, --openWith [appName]', 'open in a different app (optional)')
     .option('-a, --account [alksAccount]', 'alks account to use')
     .option('-r, --role [alksRole]', 'alks role to use')
@@ -62,14 +63,18 @@ var onComplete = function(err, key){
             utils.errorAndExit(err);
         }
 
-        var opts = !_.isEmpty(program.openWith) ? { app: program.openWith } : {};
-        opn(url, opts);
+        if (program.url) {
+            console.log(url);
+        } else {
+            var opts = !_.isEmpty(program.openWith) ? { app: program.openWith } : {};
+            opn(url, opts);
 
-        utils.log(program, logger, 'checking for updates');
-        utils.checkForUpdate(function(){
-            Developer.trackActivity(logger);
-            setTimeout(function(){ process.exit(0); }, 3000); // needed for if browser is still open
-        });
+            utils.log(program, logger, 'checking for updates');
+            utils.checkForUpdate(function(){
+                Developer.trackActivity(logger);
+                setTimeout(function(){ process.exit(0); }, 3000); // needed for if browser is still open
+            });
+        }
     });
 };
 


### PR DESCRIPTION
Using an extension in firefox like this:
https://github.com/honsiorovskyi/open-url-in-container

And its associated shell script:
https://github.com/honsiorovskyi/open-url-in-container/blob/master/launcher.sh

And an alias like this (zsh):
```
function alkssc() {
    [ -f ~/.cache/alksda ] && source ~/.cache/alksda || {
        alks developer accounts -e | sed 's/export [^=]*-[^=]*=.*//' > ~/.cache/alksda
        source ~/.cache/alksda
    }
    local alks_account
    alks_account=${AWS_PROFILE}_admin
    if [ ! -v $alks_account ]; then
        alks_account=${AWS_PROFILE}_labadmin
    fi
    local url=$(alks sessions console -i -a "${(P)alks_account}" -u)
    ~/.dotfiles/bin/firefox-container -n $AWS_PROFILE "$url"
}
```

I am able to open an AWS console in a container tab in Firefox on the command-line:
```
$ AWS_PROFILE=awsmarven alkssc
```

As a bonus, I can setup my Alfred with the following script filter:
```
import json
import os
import sys

query = sys.argv[1]

if not os.path.exists(os.path.expanduser('~/.cache/alksda')):
    os.system('''PATH=$PATH:/usr/local/bin alks developer accounts -e | sed 's/export [^=]*-[^=]*=.*//' > ~/.cache/alksda''')

with open(os.path.expanduser('~/.cache/alksda'), 'r') as f:
    items = []
    seen = set()
    for line in f.readlines():
        if line.strip() == '':
            continue
        account = line.split(' ', 1)[1].split('=', 1)[0].split('_', 1)[0]
        if account not in seen:
            seen.add(account)
            if query in account:
                items.append({
                    'uid': account,
                    'title': account,
                    'arg': account,
                })
print(json.dumps({'items': items}))
```

And run script command:
```
PATH=$PATH:/usr/local/bin
AWS_PROFILE="$1"

[ -f ~/.cache/alksda ] && source ~/.cache/alksda || {
    alks developer accounts -e | sed 's/export [^=]*-[^=]*=.*//' > ~/.cache/alksda
    source ~/.cache/alksda
}
alks_account=${AWS_PROFILE}_admin
if [ -z "${!alks_account}" ]; then
    alks_account=${AWS_PROFILE}_labadmin
fi
url=$(alks sessions console -i -a "${!alks_account}" -u)
~/.dotfiles/bin/firefox-container -n $AWS_PROFILE "$url"
```

And now, I can open AWS console in a firefox container profile via alfred:
```
alkssc labs189
```
gif demo:
![alfred_alks](https://user-images.githubusercontent.com/766820/66947312-49d3a800-f018-11e9-8c33-693f51ddb49d.gif)

