### PR TITLE
Fix critical bug in netrc handling on Linux

### DIFF
--- a/lib/developer.js
+++ b/lib/developer.js
@@ -186,7 +186,7 @@ exports.storeToken = function(token, callback){
     }
     else{
         netrc.update(SERVICETKN, {
-            token: token
+            password: token
         });
 
         chmod(utils.getFilePathInHome('.netrc'), utils.getOwnerRWOnlyPermission());
@@ -223,8 +223,8 @@ exports.getToken = function(cb){
     }
     else{
         var auth = netrc(SERVICETKN);
-        if(!_.isEmpty(auth.token)){
-            cb(auth.token);
+        if(!_.isEmpty(auth.password)){
+            cb(auth.password);
         }
         else{
             cb(null);


### PR DESCRIPTION
There's a rather critical bug in how we handle ``~/.netrc`` files, used for storing credentials on Linux. ALKS is currently treating netrc like a free-form file, but it's not; netrc files need to conform to a [given format](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) and can only include a specific, small set of tokens: ``machine <name>``, ``login <string>``, ``password <string>``, ``account <string>`` and ``macdef <macro>``.

ALKS is currently setting the ``password`` field for normal username/password credentials, but an invalid ``token <Okta Refresh Token>`` field when using 2FA auth.

This has been breaking Python's built-in netrc module:

```
$ cat ~/.netrc
machine alksclitoken
    token MyOktaRefreshTokenWouldGoHere
$ python
Python 3.7.4 (default, Oct  4 2019, 06:57:26) 
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netrc
>>> netrc.netrc()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/netrc.py", line 30, in __init__
    self._parse(file, fp, default_netrc)
  File "/usr/lib/python3.7/netrc.py", line 111, in _parse
    file, lexer.lineno)
netrc.NetrcParseError: bad follower token 'token' (/home/jantman/.netrc, line 2)
```

However, even more of a problem, this is now also breaking the latest version(s) of the terraform AWS provider using terraform 0.11.14 and terraform-provider-aws 2.34.0:

```
$ cat main.tf 
provider "aws" {}
$ terraform init

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "aws" (2.34.0)...

Error installing provider "aws": Error parsing netrc file at "/home/jantman/.netrc": line 2: keyword expected; got token.

Terraform analyses the configuration and state and automatically downloads
plugins for the providers used. However, when attempting to download this
plugin an unexpected error occured.

This may be caused if for some reason Terraform is unable to reach the
plugin repository. The repository may be unreachable if access is blocked
by a firewall.

If automatic installation is not possible or desirable in your environment,
you may alternatively manually install plugins by downloading a suitable
distribution package and placing the plugin's executable file in the
following directory:
    terraform.d/plugins/linux_amd64
```

This PR sets the ``alksclitoken`` section (machine) in netrc to use the valid ``password`` attribute for storing its token, instead of the invalid ``token`` attribute. Verification of this fix:

```
$ cat ~/.netrc
machine alksclitoken
    password MyOktaRefreshTokenWouldGoHere
jantman@phoenix:pts/8:~/tmp$ cat main.tf 
provider "aws" {}
jantman@phoenix:pts/8:~/tmp$ terraform init

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.34"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
jantman@phoenix:pts/8:~/tmp$ python
Python 3.7.4 (default, Oct  4 2019, 06:57:26) 
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netrc
>>> netrc.netrc()
machine alksclitoken
        login 
        password MyOktaRefreshTokenWouldGoHere

>>>
```

(PS - I'd really prefer to use something more secure than netrc on Linux, like FreeDesktop [Secret Service](http://standards.freedesktop.org/secret-service/) and/or KDE [KWallet](https://en.wikipedia.org/wiki/KWallet), but my nodejs skills are minimal at best.)