### PR TITLE
Token Management Deep Link Fix

### DIFF
--- a/bin/alks-developer-login2fa
+++ b/bin/alks-developer-login2fa
@@ -23,7 +23,7 @@ var logger = 'dev-login-2fa';
 utils.log(program, logger, 'loading developer');
 Developer.getDeveloper(function(err, data){
     console.error('Opening ALKS 2FA Page.. Be sure to login using Okta..');
-    opn(data.server.replace(/rest/, 'login/getToken.htm'));
+    opn(data.server.replace(/rest/, 'token-management'));
     console.error('Please copy your refresh token from ALKS and paste below..');
 
     Developer.getPasswordFromPrompt(function(err, refreshToken){


### PR DESCRIPTION
This will redirect to the new ALKS UI token management page. No longer opening the legacy ALKS refresh token page.

_Note: Should be merged once the legacy ALKS is deprecated and beta ALKS goes **live**!_

Good luck reviewer!