### PR TITLE
Normalized "Expires" Output

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -130,7 +130,7 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
             alksAccount:  encrypt(alksAccount, enc),
             alksRole:     encrypt(alksRole, enc),
             isIAM:        isIAM,
-            expires:      expires.getTime()
+            expires:      expires
         });
 
         db.save(function(err, data){

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -93,7 +93,7 @@ exports.getSessionKey = function(program, logger, alksAccount, alksRole, iamOnly
                         // store session data in DB
                         utils.log(program, logger, 'storing key: ' + JSON.stringify(key));
                         keys.addKey(key.accessKey, key.secretKey, key.sessionToken,
-                                    key.alksAccount, key.alksRole, key.expires.toDate(), auth, false);
+                                    key.alksAccount, key.alksRole, key.expires, auth, false);
                     }
                     else if(err.message.indexOf('please check API URL') !== -1){
                         err = new Error(utils.getBadAccountMessage());

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "alks",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR fixes a small defect in which a new session & resumed session would return two differently formatted `expires` values. This has been updated, and now they both return `ISO8601` formatted date strings.

Good luck reviewer! 👍 