### PR TITLE
Fix expired keys

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -130,7 +130,7 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
             alksAccount:  encrypt(alksAccount, enc),
             alksRole:     encrypt(alksRole, enc),
             isIAM:        isIAM,
-            expires:      expires
+            expires:      expires.toDate()
         });
 
         db.save(function(err, data){
@@ -141,11 +141,11 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
 
 exports.getKeys = function(auth, isIAM, callback){
     getKeysCollection(function(err, keys){
-        var now = new Date().getTime(),
+        var now = moment(),
             enc = auth.token || auth.password;
 
         // first delete any expired keys
-        keys.removeWhere({ expires : { '$lte': now } });
+        keys.removeWhere({ expires : { '$lte': now.toDate() } });
         // save the db to prune expired keys, wait for transaction to complete
         db.save(function(){
             // now get valid keys, decrypt their values and return


### PR DESCRIPTION
This PR corrects a report issue were expired keys were mistakenly being returned during `alks sessions open`.

The internal storage format was not properly comparing stored keys versus the current time to determine if they'd expired.  This PR replaces the complex date type with the native JS date type for the purposes of storage and querying to correct the issue.