### PR TITLE
Merge develop into master

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,9 @@
-★ Release Notes: 2020-05-20 ★
+★ Release Notes: 2020-06-17 ★
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
-→ Updated README.md to include `-o` and `-u` documentation
-→ Normalized the "expires" field when working with sessions
+→ [BUGFIX] Corrects an issue where the ALKS sessions command would return expired keys
 
 → Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -130,7 +130,7 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
             alksAccount:  encrypt(alksAccount, enc),
             alksRole:     encrypt(alksRole, enc),
             isIAM:        isIAM,
-            expires:      expires
+            expires:      expires.toDate()
         });
 
         db.save(function(err, data){
@@ -141,11 +141,11 @@ exports.addKey = function(accessKey, secretKey, sessionToken, alksAccount, alksR
 
 exports.getKeys = function(auth, isIAM, callback){
     getKeysCollection(function(err, keys){
-        var now = new Date().getTime(),
+        var now = moment(),
             enc = auth.token || auth.password;
 
         // first delete any expired keys
-        keys.removeWhere({ expires : { '$lte': now } });
+        keys.removeWhere({ expires : { '$lte': now.toDate() } });
         // save the db to prune expired keys, wait for transaction to complete
         db.save(function(){
             // now get valid keys, decrypt their values and return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alks",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "CLI for working with ALKS",
   "main": "bin/alks",
   "scripts": {


### PR DESCRIPTION
[BUGFIX] Corrects an issue where expired keys could be returned by `alks sessions open`.