### PR TITLE
Fix expiration format aws

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -268,7 +268,7 @@ exports.getKeyOutput = function(format, key, profile, force){
             'AccessKeyId': key.accessKey,
             'SecretAccessKey': key.secretKey,
             'SessionToken': key.sessionToken,
-            'Expiration': keyExpires
+            'Expiration': moment(key.expires).toISOString()
         });
     }
     else{


### PR DESCRIPTION
This PR corrects an issue with the expiration date format of the `aws` output type.  AWS requires a strictly ISO8601 formatted timestamp.  This was not an issue for keys generated for the AWS CLI, but some SDKs do not handle alternative date formats properly and exclude keys with incorrect formatted expiration times.

Here's more information on the expected format: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
```json
{
  "Version": 1,
  "AccessKeyId": "an AWS access key",
  "SecretAccessKey": "your AWS secret access key",
  "SessionToken": "the AWS session token for temporary credentials", 
  "Expiration": "ISO8601 timestamp when the credentials expire"
} 
```
