### PR TITLE
bumps the supported node version to 10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "8"
-  - "7"
-  - "6"
+  - "14"
+  - "12"
+  - "10"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI for working with the ALKS service.
 
 ### Prerequisites
 
-To install and use the ALKS CLI, you will need Node.js (version 4 or greater) and NPM ([nodejs.org](https://nodejs.org/en/download/package-manager)).
+To install and use the ALKS CLI, you will need Node.js (version 10 or greater) and NPM ([nodejs.org](https://nodejs.org/en/download/package-manager)).
 
 ## Installing
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "./node_modules/.bin/mocha ./test"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the supported node versions to match those supported by node's own LTS plan (older versions of node may still work with alks-cli but as of this PR we won't officially support or recommend using those older versions)