### PR TITLE
Fix #150

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chmod": "^0.2.1",
     "cli-color": "^1.1.0",
     "cli-table3": "^0.5.0",
-    "clortho": "https://github.com/Cox-Automotive/clortho/archive/1.2.4.tar.gz",
+    "clortho": "git+https://github.com/Cox-Automotive/clortho#1.2.4",
     "commander": "^2.9.0",
     "crypto": "0.0.3",
     "express": "^4.16.2",


### PR DESCRIPTION
Per the official NPM docs, the current `clortho` dependency URL is an undefined format and breaks installs on machines with valid `~/.npmrc` configuration:
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#git-urls-as-dependencies

Please merge this PR or use whatever valid syntax you prefer from that doc.