### PR TITLE
Manual changelog

### DIFF
--- a/.github/workflows/check-for-release-tag.yml
+++ b/.github/workflows/check-for-release-tag.yml
@@ -11,6 +11,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    # checkout the master branch to compare changelog.txt
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        path: ./masterbranch
+
     - name: Verify that a release label exists on the PR
       if: ${{ ! ( contains(github.event.pull_request.labels.*.name, 'release/patch') || contains(github.event.pull_request.labels.*.name, 'release/minor') || contains(github.event.pull_request.labels.*.name, 'release/major') || contains(github.event.pull_request.labels.*.name, 'release/skip') ) }}
       run: echo "Please label your PR with a release label" && exit 1
+
+    # ensure changelog.txt has been updated in this PR by comparing it to the one in the master branch
+    - name: Verify that changelog.txt has been updated
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'release/patch') || contains(github.event.pull_request.labels.*.name, 'release/minor') || contains(github.event.pull_request.labels.*.name, 'release/major') }}
+      run: cmp --silent <(tail -n+2 changelog.txt) <(tail -n+2 ./masterbranch/changelog.txt) && { echo "Changelog.txt must be updated for release PRs. Please update changelog.txt" && exit 1 ; }

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -65,18 +65,9 @@ jobs:
 
       - name: update changelog.txt
         run: |
-          cat << EOF > changelog.txt
-          ★ Release Notes: $(date +%Y-%m-%d) ★
-          ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-          
-          Thanks for upgrading to the latest version of the ALKS CLI!
-          
-          ${{ needs.get_pull_request.outputs.pull_request_body }}
-
-          Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
-
-          ☁☁☁☁☁☁  Happy Clouding! ☁☁☁☁☁☁
-          EOF
+          echo "★ Release Notes: $(date +%Y-%m-%d) ★" > changelog.temp.txt
+          tail -n +2 changelog.txt >> changelog.temp.txt
+          mv changelog.temp.txt changelog.txt
           git add changelog.txt
           git commit -m 'updates changelog.txt'
 


### PR DESCRIPTION
Patches an injection vulnerability in the trigger-release github action and requires PRs to manually update the contents of changelog.txt rather than automatically updating it from the body of the PR.