### PR TITLE
updates changelog.txt

### DIFF
--- a/.github/workflows/check-for-release-tag.yml
+++ b/.github/workflows/check-for-release-tag.yml
@@ -25,4 +25,5 @@ jobs:
     # ensure changelog.txt has been updated in this PR by comparing it to the one in the master branch
     - name: Verify that changelog.txt has been updated
       if: ${{ contains(github.event.pull_request.labels.*.name, 'release/patch') || contains(github.event.pull_request.labels.*.name, 'release/minor') || contains(github.event.pull_request.labels.*.name, 'release/major') }}
-      run: ! cmp --silent <(tail -n+2 changelog.txt) <(tail -n+2 ./masterbranch/changelog.txt) || { echo "Changelog.txt must be updated for release PRs. Please update changelog.txt" && exit 1 ; }
+      run: |
+        ! cmp --silent <(tail -n+2 changelog.txt) <(tail -n+2 ./masterbranch/changelog.txt) || { echo 'Changelog.txt must be updated for release PRs. Please update changelog.txt' && exit 1 ; }

--- a/.github/workflows/check-for-release-tag.yml
+++ b/.github/workflows/check-for-release-tag.yml
@@ -25,4 +25,4 @@ jobs:
     # ensure changelog.txt has been updated in this PR by comparing it to the one in the master branch
     - name: Verify that changelog.txt has been updated
       if: ${{ contains(github.event.pull_request.labels.*.name, 'release/patch') || contains(github.event.pull_request.labels.*.name, 'release/minor') || contains(github.event.pull_request.labels.*.name, 'release/major') }}
-      run: cmp --silent <(tail -n+2 changelog.txt) <(tail -n+2 ./masterbranch/changelog.txt) && { echo "Changelog.txt must be updated for release PRs. Please update changelog.txt" && exit 1 ; }
+      run: ! cmp --silent <(tail -n+2 changelog.txt) <(tail -n+2 ./masterbranch/changelog.txt) || { echo "Changelog.txt must be updated for release PRs. Please update changelog.txt" && exit 1 ; }

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
-Internally refactors state management to simplify logic and enable future features
+* honors the NO_COLOR environment variable for colorless output
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 

--- a/dist/changelog.txt
+++ b/dist/changelog.txt
@@ -3,7 +3,7 @@
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
-Internally refactors state management to simplify logic and enable future features
+* honors the NO_COLOR environment variable for colorless output
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 


### PR DESCRIPTION
updates the changelog to reflect changes from PR #202 whose build failed this morning. This PR should trigger the release for that PR's changes

Also fixes the boolean logic for the check that ensures changelog.txt is updated. Before this fix the check would fail regardless of if the changelogs were the same or different