### PR TITLE
ignores the dist folder in PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+dist/ linguist-generated=true
+


### PR DESCRIPTION
Makes PRs easier to review by hiding diffs for files in the `dist/` folder. Since these files are automatically generated by the build pipeline, there's no need to review them. 

Documentation: https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github