### PR TITLE
Fix same day builds

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - get_pull_request
-    if: ${{ ! contains(needs.get_pull_request.outputs.pull_request_labels, 'release/skip') }}
+    if: ${{ contains(needs.get_pull_request.outputs.pull_request_labels, 'release/patch') || contains(needs.get_pull_request.outputs.pull_request_labels, 'release/minor') || contains(needs.get_pull_request.outputs.pull_request_labels, 'release/major') }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -63,13 +63,15 @@ jobs:
         if: ${{ steps.release-label.outputs.level == null }}
         run: echo "skipping build since there is no release label on the merged PR" && exit 1
 
-      - name: update changelog.txt
+      - name: update the date in changelog.txt (if needed)
         run: |
           echo "★ Release Notes: $(date +%Y-%m-%d) ★" > changelog.temp.txt
           tail -n +2 changelog.txt >> changelog.temp.txt
-          mv changelog.temp.txt changelog.txt
-          git add changelog.txt
-          git commit -m 'updates changelog.txt'
+          if [[ ! $(cmp --silent changelog.txt changelog.temp.txt ]]; then
+            mv changelog.temp.txt changelog.txt
+            git add changelog.txt
+            git commit -m 'updates changelog.txt'
+          fi
 
       - name: Bump both git-tag and package.json version
         run: npm version "${{ steps.release-label.outputs.level }}" -m "${{ needs.get_pull_request.outputs.pull_request_title }}"
@@ -82,7 +84,7 @@ jobs:
           access-token: ${{ secrets._GITHUB_TOKEN }}
           owner: Cox-Automotive
           repo: alks-cli
-          enforce-admins: false
+          enforce_admins: false
 
       - name: Commit & Push changes
         uses: ad-m/github-push-action@master
@@ -99,7 +101,7 @@ jobs:
           access-token: ${{ secrets._GITHUB_TOKEN }}
           owner: Cox-Automotive
           repo: alks-cli
-          enforce-admins: true
+          enforce_admins: true
 
       - name: Get the latest tag
         id: previoustag

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,8 @@
 Thanks for upgrading to the latest version of the ALKS CLI!
 
 * adds more CLI options so that some actions can be performed non-interactively in a single line
+* fixes support for not saving passwords, giving you the option to enter your password every time
+* adds support for configuration using environment variables without needing to run `alks developer configure`
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 

--- a/dist/changelog.txt
+++ b/dist/changelog.txt
@@ -4,6 +4,8 @@
 Thanks for upgrading to the latest version of the ALKS CLI!
 
 * adds more CLI options so that some actions can be performed non-interactively in a single line
+* fixes support for not saving passwords, giving you the option to enter your password every time
+* adds support for configuration using environment variables without needing to run `alks developer configure`
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
 


### PR DESCRIPTION
Fixes the build automation which was previously failing if the date in `changelog.txt` was already today's date, causing there to be nothing to update which caused the pipeline to fail due to the nonzero exit code. Since this bug affected the previous 3 would-be deployments, this PR has been labelled as a release PR so that the following changes will be released:

* adds more CLI options so that some actions can be performed non-interactively in a single line
* fixes support for not saving passwords, giving you the option to enter your password every time
* adds support for configuration using environment variables without needing to run `alks developer configure`
