### PR TITLE
Optional keytar

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
-* Fixes a bug with the automatic migration of alks.db to the new ALKS config folder
+* Converts keytar to an optional dependency
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
  

--- a/dist/changelog.txt
+++ b/dist/changelog.txt
@@ -3,7 +3,7 @@
 
 Thanks for upgrading to the latest version of the ALKS CLI!
 
-* Fixes a bug with the automatic migration of alks.db to the new ALKS config folder
+* Converts keytar to an optional dependency
 
 Have feedback? https://github.com/Cox-Automotive/ALKS-CLI/issues
  

--- a/dist/package.json
+++ b/dist/package.json
@@ -49,7 +49,6 @@
         "fuzzy": "^0.1.1",
         "ini": "^2.0.0",
         "inquirer": "^6.5.2",
-        "keytar": "^7.7.0",
         "lokijs": "^1.5.1",
         "moment": "^2.13.0",
         "node-netrc": "^0.1.0",
@@ -95,7 +94,8 @@
     "optionalDependencies": {
         "express": "^4.17.1",
         "express-list-endpoints": "^3.0.1",
-        "forever": "^3.0.4"
+        "forever": "^3.0.4",
+        "keytar": "^7.7.0"
     },
     "lint-staged": {
         "src/**/*.{js,ts,json,md}": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "fuzzy": "^0.1.1",
     "ini": "^2.0.0",
     "inquirer": "^6.5.2",
-    "keytar": "^7.7.0",
     "lokijs": "^1.5.1",
     "moment": "^2.13.0",
     "node-netrc": "^0.1.0",
@@ -95,7 +94,8 @@
   "optionalDependencies": {
     "express": "^4.17.1",
     "express-list-endpoints": "^3.0.1",
-    "forever": "^3.0.4"
+    "forever": "^3.0.4",
+    "keytar": "^7.7.0"
   },
   "lint-staged": {
     "src/**/*.{js,ts,json,md}": [

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:latest
 
 RUN apt update && \
     apt install -y libgnome-keyring-dev libsecret-1-dev curl
-RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
-RUN bash n lts
+RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o /usr/local/bin/n && chmod +x /usr/local/bin/n
+RUN n lts
 RUN apt install -y gnome-keyring dbus-x11
 
 # Start the gnome keyring daemon when a bash session is initialized (requires passing --privileged when calling `docker run`)


### PR DESCRIPTION
Moves keytar to an option dependency (which it probably should have been before) since it's not necessarily needed for ALKS to run. For instance, if keytar isn't present or fails to load, the ALKS cli is capable of falling back to plaintext files or simply asking for your password each time