### PR TITLE
updates gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-dist/ linguist-generated=true
+# For reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+
+dist/ linguist-generated
 


### PR DESCRIPTION
Updates the .gitattributes file to conform to the new syntax without the `=true` part. Hopefully this will fix the bug with .gitattributes