### PR TITLE
updates code coverage action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,16 +10,16 @@ jobs:
     name: Upload Coverage to Sonarqube
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Checkout alks cli
-        run: git clone https://github.com/Cox-Automotive/alks-cli.git
-      - name: Setup node
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - run: npm ci
-      - run: npm run coverage
+          node-version: 20
+      - name: Install node modules
+        run: npm ci
+      - name: Build coverage report
+        run: npm run coverage
         env:
           CI: true
       - name: SonarQube Scan
@@ -27,3 +27,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -X

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,11 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 #sonar.projectVersion=1.0
  
 # Path is relative to the sonar-project.properties file. Defaults to .
-#sonar.sources=.
+sonar.sources=src/lib
+sonar.exclusions=src/lib/**/*.test.ts
+
+# sonar.tests=src/lib
+sonar.tests.inclusions=src/lib/**/*.test.ts
  
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Change Log Items

* Fixes code coverage action

## Description
Updates the cloudqube WAF ([here](https://ghe.coxautoinc.com/ETS-CloudAutomation/cloudqube/pull/5)) to allow github hosted runner IPs through. Also updates coverage report to distinguish between test and src files. 

#### Rally: [DE349569](https://rally1.rallydev.com/#/?detail=/defect/716593065859&fdp=true): ALKS CLI & TFP: code coverage action not working
