### PR TITLE
fix: propagate server error messages instead of swallowing them

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+★ Release Notes: 2026-04-17 ★
+≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+Thanks for upgrading to the latest version of the ALKS CLI!
+
+* Fixed error handling in IAM key retrieval to propagate server error messages instead of always showing a generic "Incorrect account or role" message.
+
 ★ Release Notes: 2026-04-09 ★
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 

--- a/src/lib/getIamKey.test.ts
+++ b/src/lib/getIamKey.test.ts
@@ -11,6 +11,7 @@ import { addKey } from './addKey';
 import ALKS from 'alks.js';
 import moment from 'moment';
 import { getAwsAccountFromString } from './getAwsAccountFromString';
+import { badAccountMessage } from './badAccountMessage';
 
 jest.mock('./ensureConfigured');
 jest.mock('./getAuth');
@@ -47,6 +48,7 @@ describe('getIamKey', () => {
     filterFavorites: boolean;
     result: Key;
     shouldThrow: boolean;
+    expectedErrorMessage?: string;
     shouldGetAlksAccount: boolean;
     shouldSaveKey: boolean;
     ensureConfigured: typeof ensureConfigured;
@@ -296,7 +298,7 @@ describe('getIamKey', () => {
     },
     {
       ...defaultTestCase,
-      description: 'when alks.getIAMKeys fails',
+      description: 'when alks.getIAMKeys fails with no message',
       getAlks: async () =>
         ({
           getLoginRole: async (props: ALKS.GetLoginRoleProps) => {
@@ -309,6 +311,24 @@ describe('getIamKey', () => {
           },
         } as unknown as ALKS.Alks),
       shouldThrow: true,
+      expectedErrorMessage: badAccountMessage,
+    },
+    {
+      ...defaultTestCase,
+      description: 'when alks.getIAMKeys fails with a server error message',
+      getAlks: async () =>
+        ({
+          getLoginRole: async (props: ALKS.GetLoginRoleProps) => {
+            return (await defaultTestCase.getAlks({} as any)).getLoginRole(
+              props
+            );
+          },
+          getIAMKeys: async () => {
+            throw new Error('Change request required for production access');
+          },
+        } as unknown as ALKS.Alks),
+      shouldThrow: true,
+      expectedErrorMessage: 'Change request required for production access',
     },
     {
       ...defaultTestCase,
@@ -331,6 +351,7 @@ describe('getIamKey', () => {
     describe(t.description, () => {
       let result: Key;
       let errorThrown: boolean = false;
+      let thrownError: Error | undefined;
 
       beforeEach(async () => {
         (ensureConfigured as jest.Mock).mockImplementation(t.ensureConfigured);
@@ -362,6 +383,7 @@ describe('getIamKey', () => {
         } catch (err) {
           console.error(err);
           errorThrown = true;
+          thrownError = err as Error;
         }
       });
 
@@ -369,6 +391,12 @@ describe('getIamKey', () => {
         it('rejects with an error', () => {
           expect(errorThrown).toBe(true);
         });
+
+        if (t.expectedErrorMessage) {
+          it('throws with the expected error message', () => {
+            expect(thrownError?.message).toBe(t.expectedErrorMessage);
+          });
+        }
       } else {
         it('resolves with the correct key', () => {
           expect(result).toEqual(expect.objectContaining(t.result));

--- a/src/lib/getIamKey.ts
+++ b/src/lib/getIamKey.ts
@@ -144,7 +144,8 @@ export async function getIamKey(
       });
     }
   } catch (e) {
-    throw new Error(badAccountMessage);
+    const serverMessage = (e as Error).message;
+    throw new Error(serverMessage || badAccountMessage);
   }
   const key: Key = {
     accessKey: alksKey.accessKey,


### PR DESCRIPTION
## Summary

- **Bug**: The `catch` block in `getIamKey.ts` (line 146-148) discards the actual server error from `alks.getIAMKeys()` and always throws a generic "Incorrect account or role" message. This prevents meaningful server-side errors from reaching the user.
- **Fix**: Propagate the server's error message when available, falling back to `badAccountMessage` only when no message is present.
- **Tests**: Updated existing test case and added a new test case verifying that server error messages (e.g., "Change request required for production access") are properly surfaced.

## Context

Starting the week of April 20, 2026, ALKS Core will enforce ChangeMinder (change ticket requirements) for production access via an Optimizely feature flag. When CLI users try to get prod keys without providing `--ciid` or `--chg-number`, the server returns a meaningful rejection message — but the CLI currently swallows it and shows "Incorrect account or role", which will confuse users and flood #alks-support.

## Changes

**`src/lib/getIamKey.ts`**
```diff
  } catch (e) {
-   throw new Error(badAccountMessage);
+   const serverMessage = (e as Error).message;
+   throw new Error(serverMessage || badAccountMessage);
  }
```

**`src/lib/getIamKey.test.ts`**
- Renamed existing "when alks.getIAMKeys fails" test to "when alks.getIAMKeys fails with no message" and added assertion that it falls back to `badAccountMessage`
- Added new test case "when alks.getIAMKeys fails with a server error message" that verifies the server message is propagated

## Test plan

- [x] `npm test` passes — all 44 tests in `getIamKey.test.ts` pass
- [ ] Manual test: run `alks sessions open` against a prod account without `--ciid`/`--chg-number` after ChangeMinder enforcement is enabled — should see the server's rejection message instead of "Incorrect account or role"

🤖 Generated with [Claude Code](https://claude.com/claude-code)