### PR TITLE
Explicitly state requirements for the -a, --account option

### DIFF
--- a/src/lib/program.ts
+++ b/src/lib/program.ts
@@ -103,7 +103,7 @@ const sessionsOpenCommand = sessions
   .description('creates or resumes a session')
   .option(
     '-a, --account <accountIdOrAlias>',
-    'the 12-digit ID or alias for an AWS account'
+    'the 12-digit ID (requires use of \'-r, --role\' option or full alias (<12-digit-id>/ALKS<Role>) for an AWS account'
   )
   .option(
     '-r, --role <authRole>',


### PR DESCRIPTION
## Change Log Items

* Change description of the -a, --account option to make requirements explicit

## Description

Using the --account option with only the 12 digit id has no effect.  Either the --role option must be specified or the role must be specified a la 123456789123/ALKSMyRoleHere

#### Rally: 
