### PR TITLE
fix: prevent silent config loss and misleading post-configure errors (F293433)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+★ Release Notes: 2026-05-21 ★
+≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+Thanks for upgrading to the latest version of the ALKS CLI!
+
+* Fixed an issue where `alks developer configure` could silently fail to persist new settings when the local config store contained an empty account record, requiring users to delete the file manually to recover.
+* Optional post-configure steps (such as shell tab completion installation) no longer abort the configure command with a misleading "Error configuring developer:" message when they fail. Failures are now reported as warnings and the configuration is preserved.
+
 ★ Release Notes: 2026-04-20 ★
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 

--- a/src/lib/handlers/alks-developer-configure.test.ts
+++ b/src/lib/handlers/alks-developer-configure.test.ts
@@ -214,14 +214,16 @@ describe('handleAlksDeveloperConfigure', () => {
     },
     {
       ...defaultTestCase,
-      description: 'when installing tab completion fails',
-      shouldErr: true,
+      description:
+        'when installing tab completion fails, configure still succeeds (post-configure step is non-critical)',
+      shouldErr: false,
       server: 'https://alks.com/rest',
       userId: 'bobby',
       password: 'letmein',
       savePassword: true,
       alksAccount: '012345678910/ALKSAdmin - awstest',
       alksRole: 'Admin',
+      outputFormat: 'env',
       shouldSaveServer: true,
       shouldSaveUserId: true,
       shouldSetPassword: true,
@@ -232,8 +234,9 @@ describe('handleAlksDeveloperConfigure', () => {
     },
     {
       ...defaultTestCase,
-      description: 'when checkForUpdate fails',
-      shouldErr: true,
+      description:
+        'when checkForUpdate fails, configure still succeeds (post-configure step is non-critical)',
+      shouldErr: false,
       server: 'https://alks.com/rest',
       userId: 'bobby',
       password: 'letmein',

--- a/src/lib/handlers/alks-developer-configure.ts
+++ b/src/lib/handlers/alks-developer-configure.ts
@@ -105,19 +105,40 @@ export async function handleAlksDeveloperConfigure(
     }
 
     console.error(clc.white('Your developer configuration has been updated.'));
-
-    if (process.stdin.isTTY && shouldPrompt) {
-      await tabtab.install({
-        name: 'alks',
-        completer: 'alks',
-      });
-    }
-
-    await checkForUpdate();
   } catch (err) {
     errorAndExit(
       'Error configuring developer: ' + (err as Error).message,
       err as Error
+    );
+  }
+
+  // Post-configure steps are non-critical: the configuration is already saved
+  // by this point. A failure here should warn and continue, not abort with a
+  // misleading "Error configuring developer:" message.
+  if (process.stdin.isTTY && !options.nonInteractive) {
+    try {
+      await tabtab.install({
+        name: 'alks',
+        completer: 'alks',
+      });
+    } catch (err) {
+      console.error(
+        clc.yellow(
+          'Warning: failed to install shell tab completion: ' +
+            (err as Error).message +
+            '. Your ALKS configuration was saved successfully; this does not affect ALKS functionality.'
+        )
+      );
+    }
+  }
+
+  try {
+    await checkForUpdate();
+  } catch (err) {
+    console.error(
+      clc.yellow(
+        'Warning: failed to check for updates: ' + (err as Error).message
+      )
     );
   }
 }

--- a/src/lib/state/developer.test.ts
+++ b/src/lib/state/developer.test.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('updateDeveloper', () => {
+  let tmpDir: string;
+  let tmpDb: string;
+  let updateDeveloper: typeof import('./developer').updateDeveloper;
+  let getDeveloper: typeof import('./developer').getDeveloper;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'alks-developer-test-'));
+    tmpDb = path.join(tmpDir, 'alks.db');
+    process.env.ALKS_DB = tmpDb;
+    jest.resetModules();
+    const mod = require('./developer');
+    updateDeveloper = mod.updateDeveloper;
+    getDeveloper = mod.getDeveloper;
+  });
+
+  afterEach(async () => {
+    delete process.env.ALKS_DB;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('persists server when no DB file exists yet', async () => {
+    await updateDeveloper({ server: 'https://example.com/rest' });
+
+    const dev = await getDeveloper();
+    expect(dev.server).toBe('https://example.com/rest');
+  });
+
+  it('preserves existing fields when updating a different field', async () => {
+    await updateDeveloper({
+      server: 'https://example.com/rest',
+      userid: 'bobby',
+    });
+    await updateDeveloper({ outputFormat: 'json' });
+
+    const dev = await getDeveloper();
+    expect(dev.server).toBe('https://example.com/rest');
+    expect(dev.userid).toBe('bobby');
+    expect(dev.outputFormat).toBe('json');
+  });
+
+  // Regression test for the double-loadDatabase bug.
+  // When the DB file exists with an empty account collection (zero records),
+  // getDeveloper returns a fresh `{}` object — not a reference into the live
+  // collection. Under the old code, getCollection was called *before*
+  // getDeveloper, so the collection reference used for the write was orphaned
+  // by the second loadDatabase. The orphaned insert was never serialized and
+  // db.save() wrote an empty collection back to disk, silently dropping the
+  // new server value.
+  it('persists server when the DB file has an empty account collection', async () => {
+    // Pre-seed the file with an empty account collection — the state that
+    // triggers the bug. Use LokiJS directly so the on-disk format includes
+    // all the collection metadata LokiJS needs to deserialize.
+    const Loki = require('lokijs');
+    await new Promise<void>((resolve, reject) => {
+      const seedDb = new Loki(tmpDb);
+      seedDb.addCollection('account');
+      seedDb.saveDatabase((err: Error | null) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    // Reload modules so the production code opens the seeded file fresh
+    jest.resetModules();
+    const mod = require('./developer');
+
+    await mod.updateDeveloper({ server: 'https://example.com/rest' });
+
+    const dev = await mod.getDeveloper();
+    expect(dev.server).toBe('https://example.com/rest');
+  });
+
+  it('updates an existing field rather than appending a duplicate', async () => {
+    await updateDeveloper({ server: 'https://old.example.com/rest' });
+    await updateDeveloper({ server: 'https://new.example.com/rest' });
+
+    const dev = await getDeveloper();
+    expect(dev.server).toBe('https://new.example.com/rest');
+  });
+});

--- a/src/lib/state/developer.ts
+++ b/src/lib/state/developer.ts
@@ -17,10 +17,11 @@ export async function getDeveloper(): Promise<Developer> {
 
 export async function updateDeveloper(newDeveloper: Developer): Promise<void> {
   log('saving developer');
-  const collection: Collection<Developer> = await getCollection('account');
 
-  collection.removeDataOnly();
-
+  // Read current state first. getDeveloper internally calls getCollection, which
+  // calls db.loadDatabase. If we obtained a collection reference *before* that,
+  // LokiJS's loadJSONObject would reset db.collections and orphan our reference,
+  // causing db.save to write stale data from disk instead of our updates.
   const developer = await getDeveloper();
 
   if (newDeveloper.server) {
@@ -55,8 +56,9 @@ export async function updateDeveloper(newDeveloper: Developer): Promise<void> {
 
   log(`saving ${JSON.stringify(developer)}`);
 
-  // LokiJS complains if we try to simply update or simply insert, and the project has been abandoned so upsert isn't coming soon
-  // TODO ^on that note, let's remove LokiJS - BW
+  // Obtain the collection AFTER reading state, so this reference is the live
+  // one attached to db.collections after the most recent loadDatabase.
+  const collection: Collection<Developer> = await getCollection('account');
   collection.clear();
   collection.insert(developer);
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `alks developer configure` that together caused users to get stuck in a "Server URL is not configured" loop and see misleading error messages.

---

## US1985865 — Fix `updateDeveloper` double-loadDatabase orphaning collection reference

**Root cause:** `updateDeveloper` obtained a LokiJS collection reference via `getCollection()`, then called `getDeveloper()` which internally called `getCollection()` a second time. Each call invokes `db.loadDatabase()` — when `alks.db` exists on disk, LokiJS resets `db.collections` and rebuilds from disk, orphaning the first reference. When the loaded collection has zero records, the `developer` object is a fresh `{}` (not a live reference), so subsequent writes target the orphaned collection and `db.save()` drops the update silently.

**Fix:** Call `getDeveloper()` first so the DB is loaded, then call `getCollection()` — guaranteeing the reference is attached to the live, post-load `db.collections`.

**Tests added:** `src/lib/state/developer.test.ts` — integration tests against a real LokiJS file using a `tmpDir` + `ALKS_DB` env var. Includes a regression test that seeds `alks.db` with an empty `account` collection to reproduce the exact failure mode.

---

## US1985867 — Wrap non-critical post-configure steps in try/catch

**Root cause:** Optional post-save steps (tab completion install, update check) ran inside the same top-level try/catch as the critical configuration writes. Any failure there called `errorAndExit('Error configuring developer: ...')` — a misleading message since the configuration had already been persisted successfully.

**Fix:** Moved both optional steps outside the main try/catch, each with its own try/catch that warns and continues. Configuration is always preserved; only the warning message changes.

---

## Test results

All 400 tests pass. `tsc --noEmit` clean. No new lint warnings.

---

Refs: F293433, US1985865, US1985867

🤖 Generated with [Claude Code](https://claude.com/claude-code)