### PR TITLE
docs: simplify Artifactory setup using Set Me Up flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Pull requests
+
+Before opening a pull request, update `changelog.txt` with an entry describing the change.

--- a/README.md
+++ b/README.md
@@ -17,20 +17,13 @@ ALKS CLI is meant to be installed via NPM from Cox Automotive's internal Artifac
 
 ### Configure NPM for Artifactory
 
-Before installing, you need to configure NPM to use the Cox Automotive Artifactory registry. Add the following to your `~/.npmrc` file:
+Before installing, you need to configure NPM to use the Cox Automotive Artifactory registry:
 
-```
-registry=https://artifactory.coxautoinc.com/artifactory/api/npm/cai-npm/
-//artifactory.coxautoinc.com/artifactory/api/npm/cai-npm/:_auth=<YOUR_ARTIFACTORY_TOKEN>
-```
-
-Replace `<YOUR_ARTIFACTORY_TOKEN>` with your Artifactory authentication token. You can obtain your token from [artifactory.coxautoinc.com](https://artifactory.coxautoinc.com) under your user profile settings.
-
-Alternatively, if you're already authenticated with JFrog CLI, you can use:
-
-```
-jf npm-config --repo-resolve cai-npm
-```
+1. Go to [artifactory.coxautoinc.com](https://artifactory.coxautoinc.com).
+2. Click on your profile in the top right.
+3. Click **Set Me Up**.
+4. Select **npm** and enter `cai-npm` for the repository.
+5. Follow the instructions provided to configure your `~/.npmrc`.
 
 **Need help?** If you have questions about configuring your `.npmrc` file or accessing Artifactory, ask in the [#artifactory](https://cox.enterprise.slack.com/archives/C8Y7NP7HN) Slack channel.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+★ Release Notes: 2026-05-29 ★
+≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+Thanks for upgrading to the latest version of the ALKS CLI!
+
+* Updated the README's Artifactory setup instructions to use the "Set Me Up" flow on artifactory.coxautoinc.com (npm / cai-npm) instead of manually editing ~/.npmrc.
+
 ★ Release Notes: 2026-05-22 ★
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 


### PR DESCRIPTION
Updates the artifactory setup instructions to match the recommended approach

## Summary
- Replace the hand-written `.npmrc` snippet (and JFrog CLI alternative) in the README with steps that route users
through Artifactory's **Set Me Up** UI for the `cai-npm` repo.
- Users no longer paste a token into `~/.npmrc` manually — Artifactory generates the correct config for them, reducing
setup errors and stale-token confusion.