### PR TITLE
fix: pass changeRequestOptions to getIamKey in session console handler

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+★ Release Notes: 2026-06-02 ★
+≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+Thanks for upgrading to the latest version of the ALKS CLI!
+
+* Fixed an issue where `alks session console --ciid`, `--activity-type`, and `--description` flags were silently ignored, causing a "change request number or primary CI must be provided" error on production accounts that require change tickets. The flags are now correctly forwarded to the key generation request.
+
 ★ Release Notes: 2026-05-29 ★
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 

--- a/src/lib/handlers/alks-sessions-console.test.ts
+++ b/src/lib/handlers/alks-sessions-console.test.ts
@@ -1,0 +1,146 @@
+import { errorAndExit } from '../errorAndExit';
+import { getIamKey } from '../getIamKey';
+import { handleAlksSessionsConsole } from './alks-sessions-console';
+import { Key } from '../../model/keys';
+
+jest.mock('../errorAndExit');
+jest.mock('../getIamKey');
+jest.mock('../checkForUpdate');
+jest.mock('../log');
+jest.mock('../getUserAgentString', () => ({
+  getUserAgentString: () => 'test-ua',
+}));
+jest.mock('../state/alksAccount');
+jest.mock('../state/alksRole');
+jest.mock('open', () => ({ default: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('axios');
+
+// Silence console output
+jest.spyOn(global.console, 'error').mockImplementation(() => {});
+jest.spyOn(global.console, 'log').mockImplementation(() => {});
+
+const mockKey: Key = {
+  accessKey: 'AKIA_FAKE',
+  secretKey: 'secret',
+  sessionToken: 'token',
+  expires: new Date(),
+  alksAccount: '254681725729',
+  alksRole: 'Admin',
+  isIAM: true,
+};
+
+const fakeErrorSymbol = Symbol('errorAndExit');
+
+describe('handleAlksSessionsConsole', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (errorAndExit as unknown as jest.Mock).mockImplementation(() => {
+      throw fakeErrorSymbol;
+    });
+    (getIamKey as jest.Mock).mockResolvedValue(mockKey);
+
+    // Mock axios for the AWS federation call inside generateConsoleUrl
+    const axios = require('axios');
+    axios.get = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { SigninToken: 'fake-signin-token' },
+    });
+  });
+
+  describe('changeRequestOptions passthrough', () => {
+    it('passes ciid/activityType/description to getIamKey when all three are provided', async () => {
+      await handleAlksSessionsConsole({
+        account: '254681725729/ALKSAdmin - awscacclogi',
+        role: 'Admin',
+        ciid: 'CI2410930',
+        activityType: 'Operational Task',
+        description: 'reviewing secret values',
+        url: true, // avoid browser open
+      });
+
+      expect(getIamKey).toHaveBeenCalledWith(
+        '254681725729/ALKSAdmin - awscacclogi',
+        'Admin',
+        undefined,
+        false,
+        false,
+        undefined,
+        {
+          ciid: 'CI2410930',
+          activityType: 'Operational Task',
+          description: 'reviewing secret values',
+        }
+      );
+    });
+
+    it('passes changeNumber to getIamKey when --chg-number is provided', async () => {
+      await handleAlksSessionsConsole({
+        account: '254681725729/ALKSAdmin - awscacclogi',
+        role: 'Admin',
+        chgNumber: 'CHG1234567',
+        url: true,
+      });
+
+      expect(getIamKey).toHaveBeenCalledWith(
+        '254681725729/ALKSAdmin - awscacclogi',
+        'Admin',
+        undefined,
+        false,
+        false,
+        undefined,
+        { changeNumber: 'CHG1234567' }
+      );
+    });
+
+    it('passes empty changeRequestOptions when no change ticket flags are provided', async () => {
+      await handleAlksSessionsConsole({
+        account: '254681725729/ALKSAdmin - awscacclogi',
+        role: 'Admin',
+        url: true,
+      });
+
+      expect(getIamKey).toHaveBeenCalledWith(
+        '254681725729/ALKSAdmin - awscacclogi',
+        'Admin',
+        undefined,
+        false,
+        false,
+        undefined,
+        { ciid: undefined, activityType: undefined, description: undefined }
+      );
+    });
+  });
+
+  describe('flag validation', () => {
+    it('calls errorAndExit when only --ciid is provided without --activity-type and --description', async () => {
+      try {
+        await handleAlksSessionsConsole({
+          account: '254681725729/ALKSAdmin - awscacclogi',
+          role: 'Admin',
+          ciid: 'CI2410930',
+        });
+      } catch (e) {
+        expect(e).toBe(fakeErrorSymbol);
+      }
+      expect(errorAndExit).toHaveBeenCalled();
+      expect(getIamKey).not.toHaveBeenCalled();
+    });
+
+    it('calls errorAndExit when --chg-number and --ciid are both provided', async () => {
+      try {
+        await handleAlksSessionsConsole({
+          account: '254681725729/ALKSAdmin - awscacclogi',
+          role: 'Admin',
+          chgNumber: 'CHG1234567',
+          ciid: 'CI2410930',
+          activityType: 'Operational Task',
+          description: 'reviewing secret values',
+        });
+      } catch (e) {
+        expect(e).toBe(fakeErrorSymbol);
+      }
+      expect(errorAndExit).toHaveBeenCalled();
+      expect(getIamKey).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/handlers/alks-sessions-console.ts
+++ b/src/lib/handlers/alks-sessions-console.ts
@@ -4,7 +4,7 @@ import { isEmpty, isUndefined } from 'underscore';
 import { Key } from '../../model/keys';
 import { checkForUpdate } from '../checkForUpdate';
 import { errorAndExit } from '../errorAndExit';
-import { getIamKey } from '../getIamKey';
+import { ChangeRequestOptions, getIamKey } from '../getIamKey';
 import { getUserAgentString } from '../getUserAgentString';
 import { log } from '../log';
 import { tryToExtractRole } from '../tryToExtractRole';
@@ -79,6 +79,17 @@ export async function handleAlksSessionsConsole(
       }
     }
 
+    let changeRequestOptions: ChangeRequestOptions;
+    if (hasChgNumber) {
+      changeRequestOptions = { changeNumber: options.chgNumber };
+    } else {
+      changeRequestOptions = {
+        ciid: options.ciid,
+        activityType: options.activityType,
+        description: options.description,
+      };
+    }
+
     let key: Key;
     try {
       key = await getIamKey(
@@ -86,7 +97,9 @@ export async function handleAlksSessionsConsole(
         alksRole,
         forceNewSession,
         filterFaves,
-        isUndefined(options.iam) ? false : true
+        isUndefined(options.iam) ? false : true,
+        undefined,
+        changeRequestOptions
       );
     } catch (err) {
       errorAndExit(err as Error);


### PR DESCRIPTION
## Summary

- `alks session console` accepted `--ciid`, `--activity-type`, and `--description` but never forwarded them to `getIamKey()` — the `changeRequestOptions` argument was never built or passed
- The ALKS backend therefore received `primaryCI: null`, causing a `BadRequestException` on prod accounts with the `alks_require_change_id` feature flag enabled (e.g. `awscacclogi`)
- Fix mirrors the `changeRequestOptions` construction already in `alks-sessions-open.ts`, which handles the same flags correctly

## Root cause

```typescript
// before — options validated but dropped
key = await getIamKey(alksAccount, alksRole, forceNewSession, filterFaves, iamOnly);

// after — changeRequestOptions built and passed
key = await getIamKey(alksAccount, alksRole, forceNewSession, filterFaves, iamOnly, undefined, changeRequestOptions);
```

## Test plan

- [ ] New test file `alks-sessions-console.test.ts` added (5 tests, all passing)
  - `--ciid`/`--activity-type`/`--description` forwarded to `getIamKey` as `{ ciid, activityType, description }`
  - `--chg-number` forwarded as `{ changeNumber }`
  - No flags → empty changeRequestOptions
  - Partial flags → `errorAndExit` called
  - `--chg-number` + `--ciid` together → `errorAndExit` called
- [ ] Full test suite passes (405 tests)
- [ ] Manually verify `alks session console --ciid <CI> --activity-type <type> --description <desc>` succeeds against a prod account with `alks_require_change_id` enabled

## Related

- Rally: F294974
- Reported by Gary Jones via #alks-support 2026-06-01
- Workaround (until this ships): `alks sessions open --ciid=... | alks session console --chg-number <N>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)